### PR TITLE
1.16.4 Fixed Mud fog

### DIFF
--- a/src/main/java/slexom/earthtojava/mobs/mixins/MudFogMixin.java
+++ b/src/main/java/slexom/earthtojava/mobs/mixins/MudFogMixin.java
@@ -52,8 +52,10 @@ public class MudFogMixin {
         Identifier mudTag = new Identifier(Earth2JavaMod.MOD_ID, "mud");
         Fluid fluid = camera.getSubmergedFluidState().getFluid();
         if (fluid.isIn(TagRegistry.fluid(mudTag))) {
-            RenderSystem.fogDensity(0.85F);
+            RenderSystem.fogStart(0.0F);
+            RenderSystem.fogEnd(1.0F);
             RenderSystem.fogMode(GlStateManager.FogMode.LINEAR);
+            RenderSystem.setupNvFogDistance();
             ci.cancel();
         }
     }


### PR DESCRIPTION
In 1.16.4, there seems to be a bug with the mud fog not displaying. It only works if you save the game submerged in mud then restart Minecraft. 

To fix it, I just copied over the Lava code, then changed the fog end distance to make it denser.

I got it close to what I think it should look like, see screenshots below:

Before:
![before](https://user-images.githubusercontent.com/47402550/99902198-9fe63680-2c81-11eb-9919-f702aba06cf8.png)

After:
![after](https://user-images.githubusercontent.com/47402550/99902218-c906c700-2c81-11eb-8324-87c31ecd7611.png)
