### PR TITLE
Fixed Glow Squid biome spawn 

### DIFF
--- a/src/main/java/slexom/earthtojava/mobs/init/EntitySpawnInit.java
+++ b/src/main/java/slexom/earthtojava/mobs/init/EntitySpawnInit.java
@@ -95,7 +95,7 @@ public class EntitySpawnInit {
     }
 
     private static void registerGlowingSquidSpawn() {
-        BiomeSpawnHelper.setWaterCreatureSpawnBiomes(EntityTypesInit.GLOW_SQUID_REGISTRY_OBJECT, BiomeSpawnHelper.GLOW_SQUID_SPAWN_BIOMES, 6, 2, 4);
+        BiomeSpawnHelper.setWaterCreatureSpawnBiomes(EntityTypesInit.GLOW_SQUID_REGISTRY_OBJECT, config.glowSquid.spawnBiomes.toArray(new String[0]), 6, 2, 4);
         SpawnRestrictionAccessor.callRegister(EntityTypesInit.GLOW_SQUID_REGISTRY_OBJECT, SpawnRestriction.Location.IN_WATER, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, GlowSquidEntity::canGlowingSquidSpawn);
     }
 }


### PR DESCRIPTION
Removed hard-coded spawn settings for Glow Squid, replaced with current config's settings.

After a quick test by adding an '!' before 'minecraft:river' in the config, this seems to work after a full restart.  