### PR TITLE
Glow Squid Spawn Config Fix

### DIFF
--- a/src/main/java/slexom/earthtojava/mobs/init/EntitySpawnInit.java
+++ b/src/main/java/slexom/earthtojava/mobs/init/EntitySpawnInit.java
@@ -95,7 +95,7 @@ public class EntitySpawnInit {
     }
 
     private static void registerGlowingSquidSpawn() {
-        BiomeSpawnHelper.setWaterCreatureSpawnBiomes(EntityTypesInit.GLOW_SQUID_REGISTRY_OBJECT, BiomeSpawnHelper.GLOW_SQUID_SPAWN_BIOMES, 6, 2, 4);
+        BiomeSpawnHelper.setWaterCreatureSpawnBiomes(EntityTypesInit.GLOW_SQUID_REGISTRY_OBJECT, config.glowSquid.spawnBiomes.toArray(new String[0]), config.glowSquid.weight, config.glowSquid.groupMin, config.glowSquid.groupMax);
         SpawnRestrictionAccessor.callRegister(EntityTypesInit.GLOW_SQUID_REGISTRY_OBJECT, SpawnRestriction.Location.IN_WATER, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, GlowSquidEntity::canGlowingSquidSpawn);
     }
 }


### PR DESCRIPTION
Removed hard-coded spawn settings for Glow Squid, replaced with autoconfig. Fixes #22 ?

I've tested the biome spawning and that seems to work, but on not 100% sure on the min, max, and spawn rates.